### PR TITLE
Create build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+# This workflow will install Python dependencies, run tests and check PEP-8 style with a single version of Python
+
+name: build mealprep package
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6.1]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6.1
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6.1
+    - name: Install dependencies
+      run: |
+        pip install poetry
+        poetry install
+#     - name: Check style
+#       run: |
+#         poetry run flake8 --exclude=docs*
+    - name: Test with pytest
+      run: |
+        poetry run pytest --cov=./ --cov-report=xml
+    - name: Upload coverage to Codecov  
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        yml: ./codecov.yml 
+        fail_ci_if_error: true


### PR DESCRIPTION
I've added the following steps to the build.yml file, but have commented out the PEP-8 style check for now while we're still working on it.

- Set up Python 3.6.1
- Install dependencies
- Check PEP-8 style #Commented out for now
- Test with pytest
- Upload coverage to Codecov