### PR TITLE
disabling branch protection settings in release.yml for testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
       with:
         ref: master
         fetch-depth: '0'
-    - name: Temporarily disable "include administrators" branch protection
-      uses: benjefferies/branch-protection-bot@master
-      if: always()
-      with:
-        access-token: ${{ secrets.ACCESS_TOKEN }}
+#    - name: Temporarily disable "include administrators" branch protection
+#      uses: benjefferies/branch-protection-bot@master
+#      if: always()
+#      with:
+#        access-token: ${{ secrets.ACCESS_TOKEN }}
     - name: Bump package versions
       run: |
         git config --local user.email "action@github.com"
@@ -53,13 +53,13 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         force: true
-    - name: Enable "include administrators" branch protection
-      uses: benjefferies/branch-protection-bot@master
-      if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
-      with:
-        access-token: ${{ secrets.ACCESS_TOKEN }}
-        owner: UBC-MDS
-        repo: mealprep
+#    - name: Enable "include administrators" branch protection
+#      uses: benjefferies/branch-protection-bot@master
+#      if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
+#      with:
+#        access-token: ${{ secrets.ACCESS_TOKEN }}
+#        owner: UBC-MDS
+#        repo: mealprep
     - name: Get release tag version from package version
       run: |
         echo ::set-output name=release_tag::$(grep "version" */__init__.py | cut -d "'" -f 2 | cut -d '"' -f 2)


### PR DESCRIPTION
I commented out the parts of the Release.yml file that have to do with branch protection so we can try this without branch protection just to see if the version updates.